### PR TITLE
Fix 'Cannot read property '1' of null'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ class BinarySupport {
       this.provider.request('CloudFormation', 'describeStacks', { StackName: this.provider.naming.getStackName(stage) }).then(resp => {
         const output = resp.Stacks[0].Outputs;
         let apiUrl;
-        output.filter(entry => entry.OutputKey.match('ServiceEndpoint')).forEach(entry => apiUrl = entry.OutputValue);
+        output.filter(entry => entry.OutputKey === 'ServiceEndpoint').forEach(entry => apiUrl = entry.OutputValue);
         const apiId = apiUrl.match('https:\/\/(.*)\\.execute-api')[1];
         resolve(apiId);
       });


### PR DESCRIPTION
Only check for `ServiceEndpoint`, match will match `ServiceEndpointWebsocket` also which does not have the same settings.

Closes #50